### PR TITLE
Read and Write Serverconfiguration from/to a file

### DIFF
--- a/resources/docker-build_p2p/ssh.rc
+++ b/resources/docker-build_p2p/ssh.rc
@@ -4,8 +4,11 @@
 ### the IP or DN of the p2p server
 p2p_server=86.119.39.89
 
+### the port of the http service in the p2p server
+http_port=800
+
 ### the port of the sshd service in the p2p server
-p2p_port=2201
+p2p_port=
 
 ### compress the ssh connections
 ### can be usefull only for slow connections

--- a/resources/docker-build_p2p/ssh.rc
+++ b/resources/docker-build_p2p/ssh.rc
@@ -1,12 +1,13 @@
 #!/bin/bash
 ### variables for the configuration of a ssh tunnel
 
-### the IP or DN of the p2p server
+#### Connection setup
+### IP or DomainName of the p2p server
+### Port of the http service in the p2p server
 p2p_server=86.119.39.89
-
-### the port of the http service in the p2p server
 http_port=800
 
+#### Configuration received from th server
 ### the port of the sshd service in the p2p server
 p2p_port=
 

--- a/resources/docker-build_p2p/use.sh
+++ b/resources/docker-build_p2p/use.sh
@@ -35,7 +35,8 @@ p2p_port=$(wget $webserver/port -O- 2>$logfile)
 ### update ssh.rc
 sed -i ssh.rc \
     -e "/^p2p_server/c p2p_server=$p2p_server" \
-    -e "/^p2p_port/c p2p_port=$p2p_port"
+    -e "/^p2p_port/c p2p_port=$p2p_port" \
+    -e "/^http_port/c http_port=$http_port"
 
 ### get the keys from the webserver
 for keyname in create delete get

--- a/src/ch/imedias/rsccfx/model/Rscc.java
+++ b/src/ch/imedias/rsccfx/model/Rscc.java
@@ -190,7 +190,7 @@ public class Rscc {
   }
 
   /**
-   * Reads Serverconfig from File pathToResourceDocker/ssh.rc
+   * Reads the docker server configuration from file ssh.rc under "/pathToResourceDocker".
    */
   private void readServerConfig() {
     String configFilePath = pathToResourceDocker + "/ssh.rc";
@@ -203,7 +203,8 @@ public class Rscc {
           setKeyServerHttpPort(line.split("=")[1]);
         }
       }
-
+      LOGGER.fine("Set serverIP to: " + getKeyServerIp()
+          + "\n Set serverHTTP-port to: " + getKeyServerHttpPort());
     } catch (IOException e) {
       LOGGER.severe("Exception thrown when reading from file: "
           + configFilePath

--- a/src/ch/imedias/rsccfx/model/Rscc.java
+++ b/src/ch/imedias/rsccfx/model/Rscc.java
@@ -6,8 +6,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
@@ -35,8 +39,8 @@ public class Rscc {
   private final SystemCommander systemCommander;
   private String pathToResourceDocker;
   private final StringProperty key = new SimpleStringProperty();
-  private final StringProperty keyServerIp = new SimpleStringProperty("86.119.39.89");
-  private final StringProperty keyServerHttpPort = new SimpleStringProperty("800");
+  private final StringProperty keyServerIp = new SimpleStringProperty();
+  private final StringProperty keyServerHttpPort = new SimpleStringProperty();
   //TODO: Replace when the StunFileGeneration is ready
   private final String pathToStunDumpFile = this.getClass()
           .getClassLoader().getResource(STUN_DUMP_FILE_NAME)
@@ -51,6 +55,7 @@ public class Rscc {
     }
     this.systemCommander = systemCommander;
     defineResourcePath();
+    readServerConfig();
   }
 
   /**
@@ -183,6 +188,29 @@ public class Rscc {
 
     return commandString.toString();
   }
+
+  /**
+   * Reads Serverconfig from File pathToResourceDocker/ssh.rc
+   */
+  private void readServerConfig() {
+    String configFilePath = pathToResourceDocker + "/ssh.rc";
+    try {
+      List<String> lines = Files.readAllLines(Paths.get(configFilePath), Charset.forName("UTF-8"));
+      for (String line : lines) {
+        if (line.contains("p2p_server=") && !line.endsWith("=")) {
+          setKeyServerIp(line.split("=")[1]);
+        } else if (line.contains("http_port=") && !line.endsWith("=")) {
+          setKeyServerHttpPort(line.split("=")[1]);
+        }
+      }
+
+    } catch (IOException e) {
+      LOGGER.severe("Exception thrown when reading from file: "
+          + configFilePath
+          + "\n Exception Message: " + e.getMessage());
+    }
+  }
+
 
   public StringProperty keyProperty() {
     return key;


### PR DESCRIPTION
Server-Configuration (IP & HTTP-Port) is read from the file docker-build_p2p/ssh.rc and also saved there by calling keyServerSetup() (use.sh). No test here because its a private method.