### PR TITLE
Fix supporters list bug

### DIFF
--- a/resources/rscc-defaults-lernstick.xml
+++ b/resources/rscc-defaults-lernstick.xml
@@ -42,4 +42,11 @@
         <encrypted>false</encrypted>
         <chargeable>false</chargeable>
     </supporter>
+    <supporter>
+        <description></description>
+        <address></address>
+        <port></port>
+        <encrypted>false</encrypted>
+        <chargeable>false</chargeable>
+    </supporter>
 </supporters>

--- a/src/ch/imedias/rsccfx/model/xml/SupporterHelper.java
+++ b/src/ch/imedias/rsccfx/model/xml/SupporterHelper.java
@@ -51,6 +51,7 @@ public class SupporterHelper {
    * Returns a default list of supporters.
    */
   public List<Supporter> getDefaultSupporters() {
+    LOGGER.info("Loading default supporter list");
     File supportersXmlFile =
         new File(getClass().getClassLoader().getResource(DEFAULT_SUPPORTERS_FILENAME).getFile());
     return getSupportersFromXml(supportersXmlFile);

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -148,7 +148,7 @@ public class RsccRequestPresenter implements ControlledPresenter {
       supporterHelper.saveSupporters(temp);
     }
 
-    supporters.stream().forEachOrdered(this::createNewSupporterBtn);
+    temp.stream().forEachOrdered(this::createNewSupporterBtn);
   }
 
   /**

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -177,6 +177,7 @@ public class RsccRequestPresenter implements ControlledPresenter {
     int column = buttonSize % GRID_MAXIMUM_COLUMNS;
     view.supporterInnerPane.add(supporterBtn, column, row);
     buttonSize++;
+    supporterHelper.saveSupporters(supporters);
   }
 
   private void attachContextMenu(Button button, Supporter supporter) {

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -148,6 +148,8 @@ public class RsccRequestPresenter implements ControlledPresenter {
     }
 
     temp.stream().forEachOrdered(this::createNewSupporterBtn);
+
+    supporterHelper.saveSupporters(supporters);
   }
 
   /**
@@ -176,7 +178,6 @@ public class RsccRequestPresenter implements ControlledPresenter {
     int column = buttonSize % GRID_MAXIMUM_COLUMNS;
     view.supporterInnerPane.add(supporterBtn, column, row);
     buttonSize++;
-    supporterHelper.saveSupporters(supporters);
   }
 
   private void attachContextMenu(Button button, Supporter supporter) {

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -28,6 +28,7 @@ public class RsccRequestPresenter implements ControlledPresenter {
   private static final Logger LOGGER =
       Logger.getLogger(RsccRequestPresenter.class.getName());
   private static final int GRID_MAXIMUM_COLUMNS = 3;
+  public static List<Supporter> supporters = new ArrayList<>();
   private final Rscc model;
   private final RsccRequestView view;
   private final HeaderPresenter headerPresenter;
@@ -35,7 +36,6 @@ public class RsccRequestPresenter implements ControlledPresenter {
   private ViewController viewParent;
   private PopOverHelper popOverHelper;
   private int buttonSize = 0;
-  public static List<Supporter> supporters = new ArrayList<>();
 
   /**
    * Initializes a new RsccRequestPresenter with the matching view.
@@ -165,7 +165,7 @@ public class RsccRequestPresenter implements ControlledPresenter {
 
     supporterBtn.setOnAction(event -> {
       // if create new button (last button) was pressed
-      if (supporters.get(supporters.size()-1) == supporter) {
+      if (supporters.get(supporters.size() - 1) == supporter) {
         createNewSupporterBtn(new Supporter());
       }
       // Open Dialog to modify data

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -145,7 +145,6 @@ public class RsccRequestPresenter implements ControlledPresenter {
     // check if invalid format of XML was found during loading
     if (temp == null) {
       temp = supporterHelper.getDefaultSupporters();
-      supporterHelper.saveSupporters(temp);
     }
 
     temp.stream().forEachOrdered(this::createNewSupporterBtn);

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -141,13 +141,13 @@ public class RsccRequestPresenter implements ControlledPresenter {
    * Calls createSupporterList() and creates a button for every supporter found.
    */
   public void initSupporterList() {
-    List<Supporter> temp = supporterHelper.loadSupporters();
+    List<Supporter> loadedSupporters = supporterHelper.loadSupporters();
     // check if invalid format of XML was found during loading
-    if (temp == null) {
-      temp = supporterHelper.getDefaultSupporters();
+    if (loadedSupporters == null) {
+      loadedSupporters = supporterHelper.getDefaultSupporters();
     }
 
-    temp.stream().forEachOrdered(this::createNewSupporterBtn);
+    loadedSupporters.stream().forEachOrdered(this::createNewSupporterBtn);
 
     supporterHelper.saveSupporters(supporters);
   }

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -6,6 +6,7 @@ import ch.imedias.rsccfx.ViewController;
 import ch.imedias.rsccfx.model.Rscc;
 import ch.imedias.rsccfx.model.xml.Supporter;
 import ch.imedias.rsccfx.model.xml.SupporterHelper;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import javafx.application.Platform;
@@ -34,8 +35,7 @@ public class RsccRequestPresenter implements ControlledPresenter {
   private ViewController viewParent;
   private PopOverHelper popOverHelper;
   private int buttonSize = 0;
-  public static List<Supporter> supporters;
-
+  public static List<Supporter> supporters = new ArrayList<>();
 
   /**
    * Initializes a new RsccRequestPresenter with the matching view.
@@ -141,23 +141,21 @@ public class RsccRequestPresenter implements ControlledPresenter {
    * Calls createSupporterList() and creates a button for every supporter found.
    */
   public void initSupporterList() {
-    supporters = supporterHelper.loadSupporters();
+    List<Supporter> temp = supporterHelper.loadSupporters();
     // check if invalid format of XML was found during loading
-    if (supporters == null) {
-      supporters = supporterHelper.getDefaultSupporters();
-      supporterHelper.saveSupporters(supporters);
+    if (temp == null) {
+      temp = supporterHelper.getDefaultSupporters();
+      supporterHelper.saveSupporters(temp);
     }
 
     supporters.stream().forEachOrdered(this::createNewSupporterBtn);
-
-    createNewSupporterBtn(new Supporter());
   }
 
   /**
    * Creates new SupporterButton and adds it to the GridPane.
    */
   public void createNewSupporterBtn(Supporter supporter) {
-
+    supporters.add(supporter);
     Button supporterBtn = new Button(supporter.toString());
     supporterBtn.getStyleClass().add("supporterBtn");
     initButtonSize(supporterBtn);

--- a/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
+++ b/src/ch/imedias/rsccfx/view/RsccRequestPresenter.java
@@ -157,14 +157,15 @@ public class RsccRequestPresenter implements ControlledPresenter {
    */
   public void createNewSupporterBtn(Supporter supporter) {
     supporters.add(supporter);
+
     Button supporterBtn = new Button(supporter.toString());
     supporterBtn.getStyleClass().add("supporterBtn");
     initButtonSize(supporterBtn);
     attachContextMenu(supporterBtn, supporter);
 
     supporterBtn.setOnAction(event -> {
-      // if create new button was pressed
-      if ("+".equals(supporter.toString())) {
+      // if create new button (last button) was pressed
+      if (supporters.get(supporters.size()-1) == supporter) {
         createNewSupporterBtn(new Supporter());
       }
       // Open Dialog to modify data
@@ -185,14 +186,12 @@ public class RsccRequestPresenter implements ControlledPresenter {
     ContextMenu contextMenu = new ContextMenu();
 
     MenuItem editMenuItem = new MenuItem("Edit");
-    // FIXME: new Supporter() must be changed to the supporter of the button
-    editMenuItem.setOnAction(event -> new SupporterAttributesDialog(supporter));
 
+    editMenuItem.setOnAction(event -> new SupporterAttributesDialog(supporter));
 
     MenuItem connectMenuItem = new MenuItem("Call");
     connectMenuItem.setOnAction(event -> {
       /*TODO start connection*/
-
     });
 
     // Add MenuItem to ContextMenu


### PR DESCRIPTION
Fixes issue #116  and #109 
- Implemented supporter list in a way that there is always an empty supporter address at the end - which is the + element
- Added logger entry when loading the default list
- Changed implementation of creating a new supporter in a way so clicking on any supporter besides the last button, even if it says "+" will not create a supporter anymore.
- Removed unnecessary TODO
- Added proper saving to XML