### PR TITLE
moved helper scripts from tempfile to mktemp

### DIFF
--- a/resources/docker-build_p2p/port_connect.sh
+++ b/resources/docker-build_p2p/port_connect.sh
@@ -58,10 +58,10 @@ then
 fi
 
 ### get the private key of the connection
-keyfile=$(tempfile)
+keyfile=$(mktemp)
 echo -e "$key\n" | ssh -o StrictHostKeyChecking=no -p $p2p_port -i keys/get.key vnc@$p2p_server > $keyfile 2>>$logfile
 
-uploadkey=$(tempfile -n /tmp/$key.stn)
+uploadkey=$(touch /tmp/$key.stn && echo /tmp/$key.stn)
 sed -n '29,$w '$uploadkey $keyfile
 sed -i '29,$d' $keyfile
 chmod 0600 $keyfile

--- a/resources/docker-build_p2p/port_share.sh
+++ b/resources/docker-build_p2p/port_share.sh
@@ -55,19 +55,19 @@ fi
 
 ### create a key pair for the connection and get
 ### the key name, remote port and the private key
-keyfile=$(tempfile)
+keyfile=$(mktemp)
 ssh -o StrictHostKeyChecking=no -p $p2p_port -i keys/create.key vnc@$p2p_server > $keyfile 2>>$logfile
 key=$(sed -n -e '1p' $keyfile | tr -d [:space:])
 remote_port=$(sed -n -e '2p' $keyfile | tr -d [:space:])
 
 ###exctract upload key
-uploadkey=$(tempfile)
+uploadkey=$(mktemp)
 sed -n '30,$w '$uploadkey $keyfile
 sed -i '30,$d' $keyfile
 chmod 0600 $keyfile
 chmod 0600 $uploadkey
 
-dumpUploadfile=$(tempfile -n /tmp/$key.stn)
+dumpUploadfile=$(touch /tmp/$key.stn && echo /tmp/$key.stn)
 cp $stunDumpFullPath $dumpUploadfile
 
 ###upload file

--- a/resources/docker-build_p2p/port_stop.sh
+++ b/resources/docker-build_p2p/port_stop.sh
@@ -43,7 +43,7 @@ then
 fi
 
 ### get the remote port from the private key
-keyfile=$(tempfile)
+keyfile=$(mktemp)
 echo -e "$key\n" | ssh -o StrictHostKeyChecking=no -p $p2p_port -i keys/get.key vnc@$p2p_server > $keyfile 2>>$logfile
 remote_port=$(head -1 $keyfile)
 rm $keyfile


### PR DESCRIPTION
This fixes #146. Now rscc can used outside of Debian. Real use outside of Debian not tested yet.